### PR TITLE
Update TravisCI for Nette utils version 2.4 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,27 +4,21 @@ language: php
 sudo: false
 
 env:
-    - NETTE=2.1
-    - NETTE=2.2
-    - NETTE=2.3
     - NETTE=2.4
     - NETTE=master
 
 php:
-    - 5.4
-    - 5.5
     - 5.6
     - 7.0
     - 7.1
+    - 7.2
+    - nightly
     - hhvm
 
 matrix:
-    exclude:
-        - php: 5.4
-          env: NETTE=2.4
-        - php: 5.5
-          env: NETTE=2.4
     allow_failures:
+        - php: 7.2
+        - php: nightly
         - php: hhvm
 
 before_install:


### PR DESCRIPTION
Podle packagistu 2.4 funguje na  PHP: 5.6 <= PHP <= 7.1